### PR TITLE
[ Init ] 폴더구조 + 라우팅 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,12 @@
+import { RouterProvider } from "react-router-dom";
+import { router } from "./Router";
+
 function App() {
-  return <></>;
+  return (
+    <>
+      <RouterProvider router={router} />
+    </>
+  );
 }
 
 export default App;

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from "react-router-dom";
+
+export const router = createBrowserRouter([
+  //   {
+  //     path: "/1",
+  //     element: <Page1 />,
+  //   },
+  //   {
+  //     path: "/2",
+  //     element: <Page2 />,
+  //   },
+  //   {
+  //     path: "/3",
+  //     element: <Page3 />,
+  //   },
+]);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,10 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx";
+import App from "./App";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const rootElement = document.getElementById("root");
+
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(<App />);
+} else {
+  console.error("Root element not found");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,6 +189,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.18.0.tgz#20b033d1f542a100c1d57cfd18ecf442d1784732"
+  integrity sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==
+
 "@rollup/rollup-android-arm-eabi@4.19.0":
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.19.0.tgz#3d9fd50164b94964f5de68c3c4ce61933b3a338d"
@@ -1603,6 +1608,21 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-router-dom@^6.25.1:
+  version "6.25.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.25.1.tgz#b89f8d63fc8383ea4e89c44bf31c5843e1f7afa0"
+  integrity sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==
+  dependencies:
+    "@remix-run/router" "1.18.0"
+    react-router "6.25.1"
+
+react-router@6.25.1:
+  version "6.25.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.25.1.tgz#70b4f1af79954cfcfd23f6ddf5c883e8c904203e"
+  integrity sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==
+  dependencies:
+    "@remix-run/router" "1.18.0"
 
 react@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #3 

## ✅ 작업 내용

- [x] 폴더구조 설정
- [x] 라우팅 설정

## 📸 스크린샷 / GIF / Link
<img width="216" alt="image" src="https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Client/assets/60962533/5670bb16-52a6-4fcf-8fb9-28abd5125c19">


## 📌 이슈 사항
파일별 역할은 다음과 같습니다!!

**assets**
에셋 저장하는 폴더 => 하위에 img, svg 폴더 존재해서 에셋을 해당하는 곳에 넣어주면 됩니다!!
index.ts는 에셋을 컴포넌트처럼 사용할 수 있도록 export해주는 파일입니다!!

**components**
컴포넌트들 저장하는 폴더 => 하위에 각 페이지 폴더 및 common 폴더가 있습니다.
공통 컴포넌트 -> common 폴더, 각 페이지에서만 사용하는 컴포넌트는 각 페이지별 폴더에 만들어서 사용하면 되겠습니다!!

**hooks**
커스텀 훅을 저장하는 폴더 => 하위에 각 페이지 폴더 및 common 폴더가 있습니다.
공통 커스텀 훅 -> common 폴더, 각 페이지에서만 사용하는 커스텀 훅은 각 페이지별 폴더에 만들어서 사용하면 되겠습니다!!

**libs**
라이브러리 관련 폴더

**pages**
페이지 컴포넌트 폴더. 각 페이지를 담당할 컴포넌트들이 위치할 폴더입니다. 컴포넌트 이름은 페이지 이름과 동일하게 생성해주시면 됩니다.

**styles**
스타일 폴더 => GlobalStyle.ts와 theme.ts가 위치할 폴더입니다.

**utils**
유틸 함수 폴더 => 하위에 각 페이지 폴더 및 common 폴더가 있습니다.
공통 유틸 함수 -> common 폴더, 각 페이지에서만 사용하는 유틸 함수는 각 페이지별 폴더에 만들어서 사용하면 되겠습니다!!

라우터 설정은 BrowserRouter가 아니라 react-router에서 권장하는 createBrowserRouter를 사용해서 세팅하였습니다.

Router.tsx에서 다음과 같이 path와 element를 매핑하여 객체로 만든 다음, 객체를 배열에 계속 추가해나가는 방식으로 라우터를 연결해주시면 됩니다!!

```ts
export const router = createBrowserRouter([
    {
      path: "/1",
      element: <Page1 />,
    },
    {
      path: "/2",
      element: <Page2 />,
    },
    {
      path: "/3",
      element: <Page3 />,
    },
    ...
]);
```

