### PR TITLE
[ Style ] 로그인 페이지 로고 및 Nav bar 안 보이도록 수정

### DIFF
--- a/src/Roots.jsx
+++ b/src/Roots.jsx
@@ -1,11 +1,14 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import TopNav from "@/components/common/TopNav";
 
 function Roots() {
+  const location = useLocation();
+  const isLoginPage = location.pathname === "/login";
+
   return (
     <>
-      <TopNav />
+      {!isLoginPage && <TopNav />}
       <Outlet />
     </>
   );

--- a/src/components/Login/LoginTop.jsx
+++ b/src/components/Login/LoginTop.jsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
+import LogoIcon from "@/assets/svgs/Logo.svg?react";
 
 const LoginTop = () => {
   return (
     <LoginTopWrapper>
-      <LogoWrapper>LOGO</LogoWrapper>
+      <LogoWrapper>
+        <StyledLogoIcon />
+      </LogoWrapper>
       <Testdescription>16가지 유형의 피부 MBTI 테스트</Testdescription>
     </LoginTopWrapper>
   );
@@ -26,6 +29,11 @@ const LogoWrapper = styled.div`
 
 const Testdescription = styled.div`
   ${({ theme }) => theme.fonts.M3_headline_large}
+`;
+
+const StyledLogoIcon = styled(LogoIcon)`
+  width: 32.7rem;
+  height: 6.65rem;
 `;
 
 export default LoginTop;


### PR DESCRIPTION
## 🔥 Related Issues

- close #35

## ✅ 작업 내용

 - [x] 로고 수정
 - [x] Nav bar 조건부 렌더링

## 📸 스크린샷 / GIF / Link
<img width="956" alt="image" src="https://github.com/user-attachments/assets/a03cd87f-5dbf-4117-ad9f-571a11df39e4">

## 📌 이슈 사항
로고 변경 및 useLocation 이용하여 pathname이 /login일 경우 TopNav 안 보이도록 작업했습니다.